### PR TITLE
Fix incorrect problem specification in problem_1.lean

### DIFF
--- a/src/lean4/human_eval/problem_1.lean
+++ b/src/lean4/human_eval/problem_1.lean
@@ -25,27 +25,11 @@ def problem_spec
 (paren_string: String) :=
 -- spec
 let paren_string_filtered := (paren_string.toList.filter (fun c => c == '(' ∨  c == ')')).asString;
-let forward_spec (result_list: List String) :=
--- every substring of the input string
--- that is a balanced paren group is in
--- the result list
-∀ i j, j < paren_string_filtered.length → i ≤ j →
-let substr_ij := (paren_string_filtered.take (j + 1)).drop i;
-balanced_paren_non_computable substr_ij '(' ')' →
-count_paren_groups substr_ij = 1 →
-substr_ij ∈ result_list;
-let backward_spec (result_list: List String) :=
--- every string in the result list is a
--- balanced paren group and is a substring
--- of the input string i.e. there is no
--- extra substring in the result list
--- that is not from the input string
-∀ str, str ∈ result_list →
-paren_string_filtered.containsSubstr str = true ∧
-balanced_paren_non_computable str '(' ')' ∧
-count_paren_groups str = 1;
 let spec (result_list: List String) :=
-forward_spec result_list ∧ backward_spec result_list;
+-- concat of result is input_filtered
+(result_list.foldl (· ++ ·) "" = paren_string_filtered) ∧
+-- each item in result is balanced and has only one group
+(∀ str ∈ result_list, balanced_paren_non_computable str '(' ')' ∧ count_paren_groups str = 1);
 -- program terminates
 ∃ result, impl paren_string = result ∧
 -- return value satisfies spec


### PR DESCRIPTION
## Problem

The previous specification for problem_1.lean was fundamentally flawed and would accept incorrect implementations.

### Old Specification Analysis

The original spec used separate conditions:

```lean
let forward_spec (result_list: List String) :=
-- every substring of the input string that is a balanced paren group is in the result list
∀ i j, j < paren_string_filtered.length → i ≤ j →
let substr_ij := (paren_string_filtered.take (j + 1)).drop i;
balanced_paren_non_computable substr_ij '(' ')' →
count_paren_groups substr_ij = 1 →
substr_ij ∈ result_list;

let backward_spec (result_list: List String) :=
-- every string in the result list is a balanced paren group and is a substring of the input string
∀ str, str ∈ result_list →
paren_string_filtered.containsSubstr str = true ∧
balanced_paren_non_computable str '(' ')' ∧
count_paren_groups str = 1;
```

### Why Old Spec Fails

**Example 1: f('(())') = ['(())', '()']**
- Forward spec: ✓ The substring '(())' (entire input) is balanced with 1 group, so it must be in result → it's there
- Backward spec: ✓ Both '(())' and '()' are substrings of '(())' (since '()' appears within '(())'), balanced, with 1 group each

**Example 2: f('()') = ['()', '()']**  
- Forward spec: ✓ The substring '()' (entire input) is balanced with 1 group, so it must be in result → it's there
- Backward spec: ✓ Both '()' entries are substrings of '()', balanced, with 1 group each

### Fundamental Issues with Old Spec

1. **No uniqueness requirement**: Allows duplicates in result list
2. **No partitioning requirement**: Doesn't ensure results actually partition/cover input exactly once  
3. **Containment ≠ Partitioning**: containsSubstr only checks if string appears somewhere in input, not proper decomposition

## Solution

### New Specification

```lean
let spec (result_list: List String) :=
-- concat of result is input_filtered
(result_list.foldl (· ++ ·) "" = paren_string_filtered) ∧
-- each item in result is balanced and has only one group
(∀ str ∈ result_list, balanced_paren_non_computable str '(' ')' ∧ count_paren_groups str = 1);
```

### Why New Spec Works

**Example 1: f('(())') = ['(())', '()']**
- Concatenation: '(())' + '()' = '(())()'  
- Filtered input: '(())'
- Since '(())()' ≠ '(())', this **fails** the spec ✓

**Example 2: f('()') = ['()', '()']**
- Concatenation: '()' + '()' = '()()'
- Filtered input: '()'  
- Since '()()' ≠ '()', this **fails** the spec ✓

### Implementation Independence

The new specification is **implementation-agnostic** and doesn't leak implementation details:
- It only specifies the mathematical relationship between input and output
- No algorithmic hints about parsing, recursion, or data structures
- Focuses purely on the correctness property: proper partitioning of balanced groups
- Critical for benchmark integrity where we want to test reasoning ability, not implementation copying

This maintains the benchmark's goal of evaluating formal reasoning capabilities without providing algorithmic guidance. 